### PR TITLE
Add keepalive-workflow to keep workflows alive, fixes #4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,3 +75,8 @@ jobs:
     - name: tests
       run: bats tests
 
+    # keepalive-workflow adds a dummy commit if there's no other action here, keeps
+    # GitHub from turning off tests after 60 days
+    - uses: gautamkrishnar/keepalive-workflow@v1
+
+


### PR DESCRIPTION
* #4 

GitHub Actions automatically turns off workflows after 60 days with no commits. Which means we lose track of these things. Keep it alive!