### PR TITLE
Update brew path as no longer provided in image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Environment setup
-      run: |
+    - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+    - run: |
         brew install bats-core mkcert
         mkcert -install
 


### PR DESCRIPTION
* https://github.com/actions/runner-images/issues/6283

brew is no longer in default $PATH